### PR TITLE
Restructure IDA Plugins

### DIFF
--- a/packages/bap-ida-plugin/bap-ida-plugin.1.0.0~alpha/descr
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.0.0~alpha/descr
@@ -1,1 +1,1 @@
-BAP plugins for interaction with IDA pro
+Plugins for IDA and BAP integration

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.0.0~alpha/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.0.0~alpha/opam
@@ -13,7 +13,7 @@ build: [
 ]
 install: [[make "install"]]
 remove: [
-        ["ocamlfind" "remove" "bap-plugin-ida"]
         ["ocamlfind" "remove" "bap-plugin-emit_ida_script"]
+        ["ocamlfind" "remove" "bap-plugin-ida-python"]
 ]
-depends: ["bap-std" "bap-ida" "cmdliner"]
+depends: ["bap" "cmdliner"]

--- a/packages/bap-ida/bap-ida.1.0.0~alpha/descr
+++ b/packages/bap-ida/bap-ida.1.0.0~alpha/descr
@@ -1,1 +1,1 @@
-A library to call IDA Pro from OCaml
+An IDA Pro integration library

--- a/packages/bap-ida/bap-ida.1.0.0~alpha/opam
+++ b/packages/bap-ida/bap-ida.1.0.0~alpha/opam
@@ -17,7 +17,10 @@ build: [
   [make]
 ]
 install: [[make "install"]]
-remove: [["ocamlfind" "remove" "bap-ida"]]
+remove: [
+        ["ocamlfind" "remove" "bap-ida"]
+        ["ocamlfind" "remove" "bap-plugin-ida_rsr"]
+]
 depends: [
          "conf-ida"
          "core_kernel"       {>= "113.24.00"}

--- a/packages/bap-traces/bap-traces.1.0.0~alpha/opam
+++ b/packages/bap-traces/bap-traces.1.0.0~alpha/opam
@@ -26,6 +26,6 @@ remove: [
 depends: [
     "oasis"             {build & >= "0.4.0"}
     "bap-std"
-    "uri"
+    "uri"               {>= "1.9.0"}
     "uuidm"
 ]

--- a/packages/bap/bap.1.0.0~alpha/opam
+++ b/packages/bap/bap.1.0.0~alpha/opam
@@ -24,6 +24,7 @@ depends: [
     "bap-print"
     "bap-std"
     "bap-symbol-reader"
+    "bap-taint"
     "bap-taint-propagator"
     "bap-term-mapper"
     "bap-trace"


### PR DESCRIPTION
This PR changes opam-repository based upon the [PR in bap](https://github.com/BinaryAnalysisPlatform/bap/pull/441) to restructure the IDA Plugins
