### PR TITLE
Add dependency on bap-ida-plugin (for bap_utils)

### DIFF
--- a/packages/bap-ida/bap-ida.1.0.0~alpha/opam
+++ b/packages/bap-ida/bap-ida.1.0.0~alpha/opam
@@ -29,4 +29,5 @@ depends: [
          "ppx_jane"          {>= "113.24.01"}
          "fileutils"
          "re"
+         "bap-ida-plugin"
 ]


### PR DESCRIPTION
Add a dependency for `bap-ida` to depend on `bap-ida-plugin` so that we can use `bap_utils.py` for IDA symbolizer, loader, etc and reduce code duplication.
