### PR TITLE
Add bap-ida-python package

### DIFF
--- a/packages/bap-ida-plugin/bap-ida-plugin.1.0.0~alpha/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.0.0~alpha/opam
@@ -14,6 +14,5 @@ build: [
 install: [[make "install"]]
 remove: [
         ["ocamlfind" "remove" "bap-plugin-emit_ida_script"]
-        ["ocamlfind" "remove" "bap-plugin-ida-python"]
 ]
 depends: ["bap" "cmdliner"]

--- a/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/descr
+++ b/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/descr
@@ -1,0 +1,1 @@
+An IDA Pro integration library

--- a/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/files/bap.cfg.in
+++ b/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/files/bap.cfg.in
@@ -1,0 +1,2 @@
+.default
+bap_executable_path    %{bap:bin}%/bap

--- a/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/files/generate-config.sh
+++ b/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/files/generate-config.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Create a bap.cfg file for use in bap-ida-python based upon path to BAP
+# passed to it as input as first argument
+
+cat > bap.cfg <<EOF
+.default
+bap_executable_path	$1
+EOF

--- a/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/files/generate-config.sh
+++ b/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/files/generate-config.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Create a bap.cfg file for use in bap-ida-python based upon path to BAP
-# passed to it as input as first argument
-
-cat > bap.cfg <<EOF
-.default
-bap_executable_path	$1
-EOF

--- a/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/opam
+++ b/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/opam
@@ -7,8 +7,8 @@ homepage: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/"
 bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/issues"
 dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-ida-python/"
 license: "MIT"
-build: [
-    ["sh" "-x" "generate-config.sh" "%{bap:bin}%/bap"]
+substs: [
+    "bap.cfg"
 ]
 install: [
     ["cp" "-v" "plugins/plugin_loader_bap.py" "%{conf-ida:path}%/plugins/"]

--- a/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/opam
+++ b/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/issues"
 dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-ida-python/"
 license: "MIT"
 build: [
-    ["sh" "-x" "generate-config.sh" "%{bap:bin}%"]
+    ["sh" "-x" "generate-config.sh" "%{bap:bin}%/bap"]
 ]
 install: [
     ["cp" "-v" "plugins/plugin_loader_bap.py" "%{conf-ida:path}%/plugins/"]

--- a/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/opam
+++ b/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bap-ida-python"
+version: "1.0.0~alpha"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap-ida-python/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap-ida-python/"
+license: "MIT"
+build: [
+    ["sh" "-x" "generate-config.sh" "%{bap:bin}%"]
+]
+install: [
+    ["cp" "-v" "plugins/plugin_loader_bap.py" "%{conf-ida:path}%/plugins/"]
+    ["cp" "-rv" "plugins/bap" "%{conf-ida:path}%/plugins/bap"]
+    ["cp" "-v" "bap.cfg" "%{conf-ida:path}%/cfg/"]
+]
+remove: [
+    ["rm" "-f" "%{conf-ida:path}%/plugins/plugin_loader_bap.py"]
+    ["rm" "-rf" "%{conf-ida:path}%/plugins/bap/"]
+    ["rm" "-f" "%{conf-ida:path}%/cfg/bap.cfg"]
+]
+depends: [
+    "bap"
+    "conf-ida"
+]

--- a/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/url
+++ b/packages/bap-ida-python/bap-ida-python.1.0.0~alpha/url
@@ -1,0 +1,1 @@
+src : "git://github.com/BinaryAnalysisPlatform/bap-ida-python.git"

--- a/packages/bap-ida/bap-ida.1.0.0~alpha/opam
+++ b/packages/bap-ida/bap-ida.1.0.0~alpha/opam
@@ -24,6 +24,7 @@ remove: [
 ]
 depends: [
          "conf-ida"
+         "bap-ida-python"
          "core_kernel"       {>= "113.24.00"}
          "oasis"             {build & >= "0.4.0"}
          "ppx_jane"          {>= "113.24.01"}


### PR DESCRIPTION
This PR adds the `bap-ida-python` package which allows the user to directly have all the necessary files from https://github.com/BinaryAnalysisPlatform/bap-ida-python installed directly using `opam install bap-ida-python`.

It also removes an artifact from an earlier time in `bap-ida-plugin`
