### PR TITLE
Use heuristic to get latest IDA

### DIFF
--- a/packages/conf-ida/conf-ida.0.1/files/find-ida.sh
+++ b/packages/conf-ida/conf-ida.0.1/files/find-ida.sh
@@ -33,7 +33,7 @@ find_command() {
 
 # can be very slow
 locate_linux() {
-    results=`locate -w -r 'idaq64$'`
+    results=`locate -w -r 'idaq64$' | sort -n -r`
 
     for path in $results; do
         if [ -x $path ]; then
@@ -46,7 +46,7 @@ locate_linux() {
 # locate on mac os x doesn't accept -r and -w flags,
 # moreover, we have a better alternative - mfind
 locate_macos() {
-    results=`mdfind -name idaq`
+    results=`mdfind -name idaq | sort -n -r`
 
     for path in $results; do
         echo "$path"


### PR DESCRIPTION
Usually the paths to different versions of IDA have a version number in them (such as `~/ida-6.9/`, `~/ida-6.6` etc). This PR uses this as a heuristic to provide an ordering to the paths to test (previously, it would just pick the first executable that `locate`/`mdfind` gave).

`sort -n -r` does a reverse numeric sort btw, and works on both linux and mac.
