### PR TITLE
locate llvm on mac os x

### DIFF
--- a/packages/bap-x86/bap-x86.1.0.0~alpha/opam
+++ b/packages/bap-x86/bap-x86.1.0.0~alpha/opam
@@ -23,5 +23,6 @@ depends: [
     "bap-std"
     "bap-abi"
     "bap-c"
+    "bap-llvm"
     "cmdliner"
 ]

--- a/packages/conf-llvm/conf-llvm.3.4/files/configure
+++ b/packages/conf-llvm/conf-llvm.3.4/files/configure
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+config="llvm-config"
+
+if ! which $config ; then
+    [ "os-$1" == "os-darwin" ] && config="llvm-config-mp-3.4"
+fi
+
+cat > conf-llvm.config <<EOF
+config: "$config"
+version: "`$config --version`"
+EOF

--- a/packages/conf-llvm/conf-llvm.3.4/opam
+++ b/packages/conf-llvm/conf-llvm.3.4/opam
@@ -5,7 +5,7 @@ bug-reports: "https://llvm.org/bugs/"
 dev-repo: "http://llvm.org/git/llvm"
 license: "BSD"
 build: [
-  ["which" "llvm-config-3.4"]
+  ["sh" "-x" "configure" os]
 ]
 depends: [
   "conf-which" {build}
@@ -14,5 +14,5 @@ depexts: [
   [["debian"] ["llvm-3.4-dev"]]
   [["ubuntu"] ["llvm-3.4-dev"]]
   [["osx" "macports"] ["llvm-3.4"]]
-  [["osx" "macports"] ["homebrew/versions/llvm34"]]
+  [["osx" "brew"] ["homebrew/versions/llvm34"]]
 ]

--- a/packages/conf-llvm/conf-llvm.3.8/files/configure
+++ b/packages/conf-llvm/conf-llvm.3.8/files/configure
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+config="llvm-config"
+
+if ! which $config ; then
+    [ "os-$1" == "os-darwin" ] && config="llvm-config-mp-3.8"
+fi
+
+cat > conf-llvm.config <<EOF
+config: "$config"
+version: "`$config --version`"
+EOF

--- a/packages/conf-llvm/conf-llvm.3.8/opam
+++ b/packages/conf-llvm/conf-llvm.3.8/opam
@@ -5,7 +5,7 @@ bug-reports: "https://llvm.org/bugs/"
 dev-repo: "http://llvm.org/git/llvm"
 license: "BSD"
 build: [
-  ["which" "llvm-config-3.8"]
+  ["sh" "-x" "configure" os]
 ]
 depends: [
   "conf-which" {build}

--- a/packages/conf-llvm/conf-llvm.system/files/configure
+++ b/packages/conf-llvm/conf-llvm.system/files/configure
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+config="llvm-config"
+
+if ! which $config ; then
+    if [ "os-$1" == "os-darwin" ]; then
+        for minor in `seq 1 10`; do
+            config="llvm-config-mp-3.$minor"
+            if which $config; then break; fi 
+        done
+    fi
+fi
+
 cat > conf-llvm.config <<EOF
-version: "$(llvm-config --version)"
+config: "$config"
+version: "`$config --version`"
 EOF

--- a/packages/conf-llvm/conf-llvm.system/opam
+++ b/packages/conf-llvm/conf-llvm.system/opam
@@ -5,8 +5,7 @@ bug-reports: "https://llvm.org/bugs/"
 dev-repo: "http://llvm.org/git/llvm"
 license: "BSD"
 build: [
-  ["which" "llvm-config"]
-  ["sh" "-x" "configure"]
+  ["sh" "-x" "configure" os]
 ]
 depends: [
   "conf-which" {build}
@@ -14,6 +13,6 @@ depends: [
 depexts: [
   [["debian"] ["llvm-dev"]]
   [["ubuntu"] ["llvm-dev"]]
-  [["osx" "macports"] ["llvm"]]
-  [["osx" "macports"] ["llvm"]]
+  [["osx" "macports"] ["llvm-3.4"]]
+  [["osx" "brew"] ["llvm"]]
 ]


### PR DESCRIPTION
This is somewhat hackish support of the llvm on Mac OS X with macports.
I didn't do anything specific from brew, but if brew has `llvm-config`
without any suffixes and prefixes installed it should work.

I also added a dependency between x86 plugin and llvm, as the former
implicitly depends on the latter (cf., arm plugin).
