### PR TITLE
conf-binutils: defer binutils installation

### DIFF
--- a/packages/conf-binutils/conf-binutils.0.1/opam
+++ b/packages/conf-binutils/conf-binutils.0.1/opam
@@ -15,13 +15,13 @@ depexts: [
   [["debian"] ["binutils-multiarch"]]
   [["ubuntu"] ["binutils-multiarch"]]
   [["osx" "macports"] [
-         "binutils"
          "arm-aout-binutils"
          "arm-elf-binutils"
          "arm-none-eabi-binutils"
          "i386-elf-binutils"
          "i386-mingw32-binutils"
          "x86_64-elf-binutils"
+         "binutils"
          ]
    ]
 ]


### PR DESCRIPTION
During the binutils installation there is a warning, that
it may broke installation of other packages. As practice
shows, this is indeed true. See BinaryAnalysisPlatform/bap#563.

Indeed, the binutils package installs the offending ansidecl.h file,
that later breaks at least mingw32-binutils. It might be better to drop
this package at all, but in this case we will loose the support for
darwin files (for the objdump package).

If later we will estimate that the amount of cons outweights the amount
of pros, provided by the bap-objdump package, then we can just drop this
package from the core bap installation and make it optional.
