### PR TITLE
constrained cmdliner to 0.9.8 version

### DIFF
--- a/packages/bap-abi/bap-abi.1.0.0/opam
+++ b/packages/bap-abi/bap-abi.1.0.0/opam
@@ -16,4 +16,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ["ocamlfind" "remove" "bap-abi"]
          ["bapbundle" "remove" "abi.plugin"]
          ]
-depends: ["bap-std" "cmdliner"]
+depends: [
+    "bap-std"
+    "cmdliner"       {= "0.9.8"}
+]

--- a/packages/bap-abi/bap-abi.1.1.0/opam
+++ b/packages/bap-abi/bap-abi.1.1.0/opam
@@ -16,4 +16,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ["ocamlfind" "remove" "bap-abi"]
          ["bapbundle" "remove" "abi.plugin"]
          ]
-depends: ["bap-std" "cmdliner"]
+depends: [
+    "bap-std"
+    "cmdliner"       {= "0.9.8"}
+]

--- a/packages/bap-abi/bap-abi.1.2.0/opam
+++ b/packages/bap-abi/bap-abi.1.2.0/opam
@@ -16,4 +16,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ["ocamlfind" "remove" "bap-abi"]
          ["bapbundle" "remove" "abi.plugin"]
          ]
-depends: ["bap-std" "cmdliner"]
+depends: [
+    "bap-std"
+    "cmdliner"       {= "0.9.8"}
+]

--- a/packages/bap-api/bap-api.1.0.0/opam
+++ b/packages/bap-api/bap-api.1.0.0/opam
@@ -16,4 +16,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ["ocamlfind" "remove" "bap-api"]
          [ "bapbundle" "remove" "api.plugin"]
          ]
-depends: ["bap-std" "cmdliner"]
+
+depends: [
+    "bap-std"
+    "cmdliner"       {= "0.9.8"}
+]

--- a/packages/bap-api/bap-api.1.1.0/opam
+++ b/packages/bap-api/bap-api.1.1.0/opam
@@ -16,4 +16,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ["ocamlfind" "remove" "bap-api"]
          [ "bapbundle" "remove" "api.plugin"]
          ]
-depends: ["bap-std" "cmdliner"]
+
+depends: [
+    "bap-std"
+    "cmdliner"       {= "0.9.8"}
+]

--- a/packages/bap-api/bap-api.1.2.0/opam
+++ b/packages/bap-api/bap-api.1.2.0/opam
@@ -16,4 +16,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ["ocamlfind" "remove" "bap-api"]
          [ "bapbundle" "remove" "api.plugin"]
          ]
-depends: ["bap-std" "cmdliner"]
+depends: [
+    "bap-std"
+    "cmdliner"       {= "0.9.8"}
+]

--- a/packages/bap-beagle/bap-beagle.1.2.0/opam
+++ b/packages/bap-beagle/bap-beagle.1.2.0/opam
@@ -16,4 +16,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
          ["ocamlfind" "remove" "bap-beagle-prey"]
          ["bapbundle" "remove" "beagle.plugin"]
          ]
-depends: ["bap-std" "cmdliner" "bap-microx"]
+depends: [
+    "bap-std"
+    "cmdliner"        {= "0.9.8"}
+    "bap-microx"
+]

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.0.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.0.0/opam
@@ -19,7 +19,7 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
     "bap-std"
     "bap-byteweight"
-    "cmdliner"
+    "cmdliner"           {= "0.9.8"}
     "ocurl"
     "fileutils"
     "re"

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.1.0/opam
@@ -19,7 +19,7 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
     "bap-std"
     "bap-byteweight"
-    "cmdliner"
+    "cmdliner"           {= "0.9.8"}
     "ocurl"
     "fileutils"
     "re"

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.2.0/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.1.2.0/opam
@@ -19,7 +19,7 @@ remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 depends: [
     "bap-std"
     "bap-byteweight"
-    "cmdliner"
+    "cmdliner"           {= "0.9.8"}
     "ocurl"
     "fileutils"
     "re"

--- a/packages/bap-cache/bap-cache.1.0.0/opam
+++ b/packages/bap-cache/bap-cache.1.0.0/opam
@@ -22,5 +22,5 @@ remove: [
 
 depends: [
     "bap-std"
-    "cmdliner"
+    "cmdliner"       {= "0.9.8"}
 ]

--- a/packages/bap-cache/bap-cache.1.1.0/opam
+++ b/packages/bap-cache/bap-cache.1.1.0/opam
@@ -22,5 +22,5 @@ remove: [
 
 depends: [
     "bap-std"
-    "cmdliner"
+    "cmdliner"       {= "0.9.8"}
 ]

--- a/packages/bap-cache/bap-cache.1.2.0/opam
+++ b/packages/bap-cache/bap-cache.1.2.0/opam
@@ -22,5 +22,5 @@ remove: [
 
 depends: [
     "bap-std"
-    "cmdliner"
+    "cmdliner"       {= "0.9.8"}
 ]

--- a/packages/bap-callsites/bap-callsites.1.0.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.0.0/opam
@@ -27,5 +27,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-callsites/bap-callsites.1.1.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.1.0/opam
@@ -27,5 +27,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-callsites/bap-callsites.1.2.0/opam
+++ b/packages/bap-callsites/bap-callsites.1.2.0/opam
@@ -27,5 +27,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-demangle/bap-demangle.1.0.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.0.0/opam
@@ -24,5 +24,5 @@ depends: [
     "core_kernel"       {>= "113.24.00"}
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-demangle/bap-demangle.1.1.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.1.0/opam
@@ -24,5 +24,5 @@ depends: [
     "core_kernel"       {>= "113.24.00"}
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-demangle/bap-demangle.1.2.0/opam
+++ b/packages/bap-demangle/bap-demangle.1.2.0/opam
@@ -24,5 +24,5 @@ depends: [
     "core_kernel"       {>= "113.24.00"}
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.0.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.0.0/opam
@@ -21,5 +21,5 @@ remove: [
 
 depends: [
     "bap-std"
-    "cmdliner"
+    "cmdliner"      {= "0.9.8"}
 ]

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.1.0/opam
@@ -21,5 +21,5 @@ remove: [
 
 depends: [
     "bap-std"
-    "cmdliner"
+    "cmdliner"      {= "0.9.8"}
 ]

--- a/packages/bap-dump-symbols/bap-dump-symbols.1.2.0/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.1.2.0/opam
@@ -21,5 +21,5 @@ remove: [
 
 depends: [
     "bap-std"
-    "cmdliner"
+    "cmdliner"      {= "0.9.8"}
 ]

--- a/packages/bap-frames/bap-frames.2.1.0/opam
+++ b/packages/bap-frames/bap-frames.2.1.0/opam
@@ -28,6 +28,6 @@ depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
     "bap-traces"
-    "cmdliner"
-    "piqi" {>= "0.7.4"}
+    "cmdliner"          {= "0.9.8"}
+    "piqi"              {>= "0.7.4"}
 ]

--- a/packages/bap-frontend/bap-frontend.1.0.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.0.0/opam
@@ -26,5 +26,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-frontend/bap-frontend.1.1.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.1.0/opam
@@ -26,5 +26,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-frontend/bap-frontend.1.2.0/opam
+++ b/packages/bap-frontend/bap-frontend.1.2.0/opam
@@ -26,5 +26,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.0.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.0.0/opam
@@ -20,7 +20,7 @@ depends: [
     "bap-std"
     "bap-ida"
     "bap-byteweight-frontend"
-    "cmdliner"
+    "cmdliner"                {= "0.9.8"}
     "fileutils"
     "re"
 ]

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.1.0/opam
@@ -20,7 +20,7 @@ depends: [
     "bap-std"
     "bap-ida"
     "bap-byteweight-frontend"
-    "cmdliner"
+    "cmdliner"                {= "0.9.8"}
     "fileutils"
     "re"
 ]

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.2.0/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.1.2.0/opam
@@ -20,7 +20,7 @@ depends: [
     "bap-std"
     "bap-ida"
     "bap-byteweight-frontend"
-    "cmdliner"
+    "cmdliner"                {= "0.9.8"}
     "fileutils"
     "re"
 ]

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.0.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.0.0/opam
@@ -17,4 +17,7 @@ remove: [
         [ "bapbundle" "remove" "emit_ida_script.plugin"]
 
 ]
-depends: ["bap" "cmdliner"]
+depends: [
+    "bap"
+    "cmdliner"      {= "0.9.8"}
+]

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.1.0/opam
@@ -17,4 +17,7 @@ remove: [
         [ "bapbundle" "remove" "emit_ida_script.plugin"]
 
 ]
-depends: ["bap" "cmdliner"]
+depends: [
+    "bap"
+    "cmdliner"      {= "0.9.8"}
+]

--- a/packages/bap-ida-plugin/bap-ida-plugin.1.2.0/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.1.2.0/opam
@@ -17,4 +17,7 @@ remove: [
         [ "bapbundle" "remove" "emit_ida_script.plugin"]
 
 ]
-depends: ["bap" "cmdliner"]
+depends: [
+    "bap"
+    "cmdliner"      {= "0.9.8"}
+]

--- a/packages/bap-llvm/bap-llvm.1.0.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.0.0/opam
@@ -30,7 +30,7 @@ remove: [
 
 depends: [
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
     ("conf-bap-llvm" | "conf-llvm")
     "conf-env-travis"
 ]

--- a/packages/bap-llvm/bap-llvm.1.1.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.1.0/opam
@@ -30,7 +30,7 @@ remove: [
 
 depends: [
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
     ("conf-bap-llvm" | "conf-llvm")
     "conf-env-travis"
 ]

--- a/packages/bap-llvm/bap-llvm.1.2.0/opam
+++ b/packages/bap-llvm/bap-llvm.1.2.0/opam
@@ -31,7 +31,7 @@ remove: [
 
 depends: [
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
     ("conf-bap-llvm" | "conf-llvm")
     "conf-env-travis"
 ]

--- a/packages/bap-mc/bap-mc.1.0.0/opam
+++ b/packages/bap-mc/bap-mc.1.0.0/opam
@@ -26,5 +26,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-mc/bap-mc.1.1.0/opam
+++ b/packages/bap-mc/bap-mc.1.1.0/opam
@@ -26,5 +26,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-mc/bap-mc.1.2.0/opam
+++ b/packages/bap-mc/bap-mc.1.2.0/opam
@@ -26,5 +26,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-objdump/bap-objdump.1.0.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.0.0/opam
@@ -17,6 +17,11 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
-	 ["bapbundle" "remove" "objdump.plugin"]
+     ["bapbundle" "remove" "objdump.plugin"]
 ]
-depends: ["bap-std" "re" "cmdliner" "conf-binutils"]
+depends: [
+    "bap-std"
+    "re"
+    "cmdliner"             {= "0.9.8"}
+    "conf-binutils"
+]

--- a/packages/bap-objdump/bap-objdump.1.1.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.1.0/opam
@@ -17,6 +17,11 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
-	 ["bapbundle" "remove" "objdump.plugin"]
+     ["bapbundle" "remove" "objdump.plugin"]
 ]
-depends: ["bap-std" "re" "cmdliner" "conf-binutils"]
+depends: [
+    "bap-std"
+    "re"
+    "cmdliner"             {= "0.9.8"}
+    "conf-binutils"
+]

--- a/packages/bap-objdump/bap-objdump.1.2.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.2.0/opam
@@ -17,6 +17,11 @@ build: [
 ]
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
-	 ["bapbundle" "remove" "objdump.plugin"]
+     ["bapbundle" "remove" "objdump.plugin"]
 ]
-depends: ["bap-std" "re" "cmdliner" "conf-binutils"]
+depends: [
+    "bap-std"
+    "re"
+    "cmdliner"             {= "0.9.8"}
+    "conf-binutils"
+]

--- a/packages/bap-phoenix/bap-phoenix.1.0.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.0.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
     "text-tags"
     "ocamlgraph"
     "ezjsonm"

--- a/packages/bap-phoenix/bap-phoenix.1.1.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.1.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
     "text-tags"
     "ocamlgraph"
     "ezjsonm"

--- a/packages/bap-phoenix/bap-phoenix.1.2.0/opam
+++ b/packages/bap-phoenix/bap-phoenix.1.2.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
     "text-tags"
     "ocamlgraph"
     "ezjsonm"

--- a/packages/bap-piqi/bap-piqi.1.0.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.0.0/opam
@@ -30,7 +30,7 @@ remove: [
 depends: [
     "oasis"             {build & >= "0.4.7"}
     "bap-std"
-    "cmdliner"
-    "piqi" {>= "0.7.4"}
+    "cmdliner"          {= "0.9.8"}
+    "piqi"              {>= "0.7.4"}
 
 ]

--- a/packages/bap-piqi/bap-piqi.1.1.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.1.0/opam
@@ -30,7 +30,7 @@ remove: [
 depends: [
     "oasis"             {build & >= "0.4.7"}
     "bap-std"
-    "cmdliner"
-    "piqi" {>= "0.7.4"}
+    "cmdliner"          {= "0.9.8"}
+    "piqi"              {>= "0.7.4"}
 
 ]

--- a/packages/bap-piqi/bap-piqi.1.2.0/opam
+++ b/packages/bap-piqi/bap-piqi.1.2.0/opam
@@ -30,7 +30,7 @@ remove: [
 depends: [
     "oasis"             {build & >= "0.4.7"}
     "bap-std"
-    "cmdliner"
-    "piqi" {>= "0.7.4"}
+    "cmdliner"          {= "0.9.8"}
+    "piqi"              {>= "0.7.4"}
 
 ]

--- a/packages/bap-std/bap-std.1.0.0/opam
+++ b/packages/bap-std/bap-std.1.0.0/opam
@@ -44,7 +44,7 @@ depends: [
   "utop"
   "uuidm"
   "zarith"
-  "cmdliner" {<= "0.9.8"}
+  "cmdliner" {= "0.9.8"}
 ]
 depexts: [
     [["ubuntu"] [

--- a/packages/bap-std/bap-std.1.1.0/opam
+++ b/packages/bap-std/bap-std.1.1.0/opam
@@ -44,7 +44,7 @@ depends: [
   "utop"
   "uuidm"
   "zarith"
-  "cmdliner" {<= "0.9.8"}
+  "cmdliner" {= "0.9.8"}
 ]
 depexts: [
     [["ubuntu"] [

--- a/packages/bap-std/bap-std.1.2.0/opam
+++ b/packages/bap-std/bap-std.1.2.0/opam
@@ -44,7 +44,7 @@ depends: [
   "utop"
   "uuidm"
   "zarith"
-  "cmdliner" {<= "0.9.8"}
+  "cmdliner" {= "0.9.8"}
 ]
 depexts: [
     [["ubuntu"] [

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.0.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.0.0/opam
@@ -28,5 +28,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.1.0/opam
@@ -28,5 +28,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-symbol-reader/bap-symbol-reader.1.2.0/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.1.2.0/opam
@@ -28,5 +28,5 @@ remove: [
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.0.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.0.0/opam
@@ -14,4 +14,9 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
          ["bapbundle" "remove" "propagate_taint.plugin"]]
-depends: ["bap-std" "cmdliner" "bap-microx"]
+
+depends: [
+    "bap-std"
+    "cmdliner"       {= "0.9.8"}
+    "bap-microx"
+]

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.1.0/opam
@@ -14,4 +14,9 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
          ["bapbundle" "remove" "propagate_taint.plugin"]]
-depends: ["bap-std" "cmdliner" "bap-microx"]
+
+depends: [
+    "bap-std"
+    "cmdliner"       {= "0.9.8"}
+    "bap-microx"
+]

--- a/packages/bap-taint-propagator/bap-taint-propagator.1.2.0/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.1.2.0/opam
@@ -14,4 +14,8 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
          ["bapbundle" "remove" "propagate_taint.plugin"]]
-depends: ["bap-std" "cmdliner" "bap-microx"]
+depends: [
+    "bap-std"
+    "cmdliner"       {= "0.9.8"}
+    "bap-microx"
+]

--- a/packages/bap-taint/bap-taint.1.0.0/opam
+++ b/packages/bap-taint/bap-taint.1.0.0/opam
@@ -14,4 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-taint"]
          ["bapbundle" "remove" "taint.plugin"]]
-depends: ["bap-std" "cmdliner"]
+depends: [
+    "bap-std"
+    "cmdliner"     {= "0.9.8"}
+]

--- a/packages/bap-taint/bap-taint.1.1.0/opam
+++ b/packages/bap-taint/bap-taint.1.1.0/opam
@@ -14,4 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-taint"]
          ["bapbundle" "remove" "taint.plugin"]]
-depends: ["bap-std" "cmdliner"]
+depends: [
+    "bap-std"
+    "cmdliner"     {= "0.9.8"}
+]

--- a/packages/bap-taint/bap-taint.1.2.0/opam
+++ b/packages/bap-taint/bap-taint.1.2.0/opam
@@ -14,4 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-taint"]
          ["bapbundle" "remove" "taint.plugin"]]
-depends: ["bap-std" "cmdliner"]
+depends: [
+    "bap-std"
+    "cmdliner"     {= "0.9.8"}
+]

--- a/packages/bap-term-mapper/bap-term-mapper.1.0.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.0.0/opam
@@ -27,5 +27,5 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-term-mapper/bap-term-mapper.1.1.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.1.0/opam
@@ -27,5 +27,5 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-term-mapper/bap-term-mapper.1.2.0/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.1.2.0/opam
@@ -27,5 +27,5 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-trace/bap-trace.1.0.0/opam
+++ b/packages/bap-trace/bap-trace.1.0.0/opam
@@ -28,5 +28,5 @@ depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
     "bap-traces"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-trace/bap-trace.1.1.0/opam
+++ b/packages/bap-trace/bap-trace.1.1.0/opam
@@ -28,5 +28,5 @@ depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
     "bap-traces"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-trace/bap-trace.1.2.0/opam
+++ b/packages/bap-trace/bap-trace.1.2.0/opam
@@ -28,5 +28,5 @@ depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
     "bap-traces"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-veri/bap-veri.0.2/opam
+++ b/packages/bap-veri/bap-veri.0.2/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
     "bap-std"
     "bap-traces"
-    "cmdliner"
+    "cmdliner"    {= "0.9.8"}
     "oasis"       {build}
     "ounit"
     "pcre"

--- a/packages/bap-warn-unused/bap-warn-unused.1.0.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.0.0/opam
@@ -25,5 +25,5 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-warn-unused/bap-warn-unused.1.1.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.1.0/opam
@@ -25,5 +25,5 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-warn-unused/bap-warn-unused.1.2.0/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.1.2.0/opam
@@ -25,5 +25,5 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
 depends: [
     "oasis"             {build & = "0.4.7"}
     "bap-std"
-    "cmdliner"
+    "cmdliner"          {= "0.9.8"}
 ]

--- a/packages/bap-x86/bap-x86.1.0.0/opam
+++ b/packages/bap-x86/bap-x86.1.0.0/opam
@@ -26,5 +26,5 @@ depends: [
     "bap-abi"
     "bap-c"
     "bap-llvm"
-    "cmdliner"
+    "cmdliner"        {= "0.9.8"}
 ]

--- a/packages/bap-x86/bap-x86.1.1.0/opam
+++ b/packages/bap-x86/bap-x86.1.1.0/opam
@@ -27,5 +27,5 @@ depends: [
     "bap-abi"
     "bap-c"
     "bap-llvm"
-    "cmdliner"
+    "cmdliner"        {= "0.9.8"}
 ]

--- a/packages/bap-x86/bap-x86.1.2.0/opam
+++ b/packages/bap-x86/bap-x86.1.2.0/opam
@@ -26,5 +26,5 @@ depends: [
     "bap-abi"
     "bap-c"
     "bap-llvm"
-    "cmdliner"
+    "cmdliner"        {= "0.9.8"}
 ]


### PR DESCRIPTION
constrained cmdliner version to `0.9.8`. Basicly it can't be less (due to a `Term.const` usage, that is available only from `0.9.8`) and greater (since 
some packages, e.g. `depext` doesn't support `1.0.0`)