### PR TITLE
adds constraints for bap-ida and bap-ida-python 

### DIFF
--- a/packages/bap-ida-python/bap-ida-python.1.2.0/opam
+++ b/packages/bap-ida-python/bap-ida-python.1.2.0/opam
@@ -21,6 +21,6 @@ remove: [
     ["rm" "-f" "%{conf-ida:path}%/cfg/bap.cfg"]
 ]
 depends: [
-    "bap" {>= "1.1.0"}
+    "bap" {= "1.2.0"}
     "conf-ida"
 ]

--- a/packages/bap-ida/bap-ida.1.0.0/opam
+++ b/packages/bap-ida/bap-ida.1.0.0/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 depends: [
          "conf-ida"
-         "bap-ida-python"
+         "bap-ida-python"    {= "1.0.0"}
          "core_kernel"       {>= "113.24.00"}
          "oasis"             {build & = "0.4.7"}
          "ppx_jane"          {>= "113.24.01"}

--- a/packages/bap-ida/bap-ida.1.1.0/opam
+++ b/packages/bap-ida/bap-ida.1.1.0/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 depends: [
          "conf-ida"
-         "bap-ida-python"
+         "bap-ida-python"    {= "1.1.0"}
          "core_kernel"       {>= "113.24.00"}
          "oasis"             {build & = "0.4.7"}
          "ppx_jane"          {>= "113.24.01"}

--- a/packages/bap-ida/bap-ida.1.2.0/opam
+++ b/packages/bap-ida/bap-ida.1.2.0/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 depends: [
          "conf-ida"
-         "bap-ida-python"
+         "bap-ida-python"    {= "1.2.0"}
          "core_kernel"       {>= "113.24.00"}
          "oasis"             {build & = "0.4.7"}
          "ppx_jane"          {>= "113.24.01"}

--- a/packages/bap-ida/bap-ida.1.3.0/opam
+++ b/packages/bap-ida/bap-ida.1.3.0/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 depends: [
          "conf-ida"
-         "bap-ida-python"
+         "bap-ida-python"    {= "1.3.0"}
          "core_kernel"       {>= "113.24.00"}
          "oasis"             {build & = "0.4.7"}
          "ppx_jane"          {>= "113.24.01"}

--- a/packages/bap-ida/bap-ida.master/opam
+++ b/packages/bap-ida/bap-ida.master/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 depends: [
          "conf-ida"
-         "bap-ida-python"
+         "bap-ida-python"    {>= "1.3.0"}
          "core_kernel"       {>= "113.24.00"}
          "oasis"             {build & = "0.4.7"}
          "ppx_jane"          {>= "113.24.01"}


### PR DESCRIPTION
adds constraining for dependencies of `bap-ida` and `bap-ida-python`packages, e.g. `bap-ida.1.2.0` depends now on `bap-ida-python.1.2.0`, and the later one in his turn depends on `bap.1.2.0`.

fix https://github.com/BinaryAnalysisPlatform/bap/issues/719