### PR TITLE
drops constraint on `re` version for bap-objdump

### DIFF
--- a/packages/bap-objdump/bap-objdump.master/opam
+++ b/packages/bap-objdump/bap-objdump.master/opam
@@ -22,7 +22,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
 depends: [
   "ocaml" {>= "4.04.1"}
   "bap-std" {= "master"}
-  "re" {< "1.7.2"}
+  "re"
   "cmdliner"
   "conf-binutils"
 ]


### PR DESCRIPTION
for some reasons `bap-objdump` has constraint ` "re" {< "1.7.2"} `. First of all, it's the only bap package that has such constraint, but not the one who uses `re`. And there are no problems occurred while building
bap with  `re.1.7.2` and newer version `re.1.8.0`.
Also, the modern version of `uri` package depends on `re.1.8.0`.
So looks like we don't need this constraint at all.