### PR TITLE
Makes testing branch even with bap-1.6

### DIFF
--- a/packages/bap-abi/bap-abi.master/opam
+++ b/packages/bap-abi/bap-abi.master/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ["bapbundle" "remove" "abi.plugin"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-api/bap-api.master/opam
+++ b/packages/bap-api/bap-api.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ["rm" "-rf" "%{prefix}%/share/bap-api/c"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-arm/bap-arm.master/opam
+++ b/packages/bap-arm/bap-arm.master/opam
@@ -22,7 +22,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-llvm"
   "bap-abi"

--- a/packages/bap-beagle/bap-beagle.master/opam
+++ b/packages/bap-beagle/bap-beagle.master/opam
@@ -19,7 +19,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
          ["bapbundle" "remove" "strings.plugin"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "cmdliner"
   "bap-microx"

--- a/packages/bap-bil/bap-bil.master/opam
+++ b/packages/bap-bil/bap-bil.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-bil"]
          ["bapbundle" "remove" "bil.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.master/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-byteweight"
   "cmdliner"

--- a/packages/bap-byteweight/bap-byteweight.master/opam
+++ b/packages/bap-byteweight/bap-byteweight.master/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-signatures"
 ]

--- a/packages/bap-c/bap-c.master/opam
+++ b/packages/bap-c/bap-c.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-c"]]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-api"
 ]

--- a/packages/bap-cache/bap-cache.master/opam
+++ b/packages/bap-cache/bap-cache.master/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-callsites/bap-callsites.master/opam
+++ b/packages/bap-callsites/bap-callsites.master/opam
@@ -25,7 +25,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-constant-tracker/bap-constant-tracker.master/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-costant_tracker"]
          ["bapbundle" "remove" "constant_tracker.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-cxxfilt/bap-cxxfilt.master/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.master/opam
@@ -21,7 +21,7 @@ remove: [
         ["bapbundle" "remove" "cxxfilt.plugin"]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-demangle"
   "conf-binutils" {>= "0.2"}

--- a/packages/bap-demangle/bap-demangle.master/opam
+++ b/packages/bap-demangle/bap-demangle.master/opam
@@ -21,7 +21,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}

--- a/packages/bap-dump-symbols/bap-dump-symbols.master/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.master/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-dwarf/bap-dwarf.master/opam
+++ b/packages/bap-dwarf/bap-dwarf.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-dwarf"]]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "BAP DWARF parsing library"

--- a/packages/bap-elf/bap-elf.master/opam
+++ b/packages/bap-elf/bap-elf.master/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-dwarf"
   "bitstring" {>= "3.0.0"}

--- a/packages/bap-frames/bap-frames.master/opam
+++ b/packages/bap-frames/bap-frames.master/opam
@@ -35,7 +35,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "ppx_jane" {>= "v0.11" & < "v0.12"}

--- a/packages/bap-frontc/bap-frontc.master/opam
+++ b/packages/bap-frontc/bap-frontc.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
         ["bapbundle" "remove" "frontc_parser.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-c"
   "FrontC"

--- a/packages/bap-frontend/bap-frontend.master/opam
+++ b/packages/bap-frontend/bap-frontend.master/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-frontend/bap-frontend.master/opam
+++ b/packages/bap-frontend/bap-frontend.master/opam
@@ -28,7 +28,7 @@ depends: [
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"
-  "parsexp"
+  "parsexp" {>= "v0.11" & < "v0.12"}
 ]
 synopsis: "BAP frontend"
 description: "The command-line interface to the Binary Analysis Platform."

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.master/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-ida"
   "bap-byteweight-frontend"

--- a/packages/bap-future/bap-future.master/opam
+++ b/packages/bap-future/bap-future.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-future"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build & >= "0.4.7"}
   "monads"

--- a/packages/bap-ida-plugin/bap-ida-plugin.master/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.master/opam
@@ -18,7 +18,7 @@ remove: [
 
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap"
   "cmdliner"
 ]

--- a/packages/bap-ida-python/bap-ida-python.master/opam
+++ b/packages/bap-ida-python/bap-ida-python.master/opam
@@ -20,7 +20,7 @@ remove: [
     ["rm" "-rf" "%{prefix}%/share/%{name}%/"]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap" {= "master"}
   "conf-ida"
 ]

--- a/packages/bap-ida/bap-ida.master/opam
+++ b/packages/bap-ida/bap-ida.master/opam
@@ -23,7 +23,7 @@ remove: [
         ["bapbundle" "remove" "ida.plugin"]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "conf-ida"
   "bap-ida-python" {>= "1.5.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}

--- a/packages/bap-llvm/bap-llvm.master/opam
+++ b/packages/bap-llvm/bap-llvm.master/opam
@@ -28,7 +28,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "cmdliner"
   "conf-env-travis"

--- a/packages/bap-mc/bap-mc.master/opam
+++ b/packages/bap-mc/bap-mc.master/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-microx/bap-microx.master/opam
+++ b/packages/bap-microx/bap-microx.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-microx"]]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "A micro execution framework"

--- a/packages/bap-mips/bap-mips.master/opam
+++ b/packages/bap-mips/bap-mips.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-mips"]
          ["bapbundle" "remove" "mips.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-abi"
   "bap-c"

--- a/packages/bap-objdump/bap-objdump.master/opam
+++ b/packages/bap-objdump/bap-objdump.master/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
 	 ["bapbundle" "remove" "objdump.plugin"]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "re"
   "cmdliner"

--- a/packages/bap-optimization/bap-optimization.master/opam
+++ b/packages/bap-optimization/bap-optimization.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-optimization"]
          ["bapbundle" "remove" "optimization.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-phoenix/bap-phoenix.master/opam
+++ b/packages/bap-phoenix/bap-phoenix.master/opam
@@ -25,7 +25,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-piqi/bap-piqi.master/opam
+++ b/packages/bap-piqi/bap-piqi.master/opam
@@ -30,7 +30,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-powerpc/bap-powerpc.master/opam
+++ b/packages/bap-powerpc/bap-powerpc.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
          ["bapbundle" "remove" "powerpc.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-abi"
   "bap-c"
   "bap-primus" {= "master"}

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.master/opam
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-primus-lisp/bap-primus-lisp.master/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.master/opam
@@ -21,7 +21,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-primus-region/bap-primus-region.master/opam
+++ b/packages/bap-primus-region/bap-primus-region.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-primus-support/bap-primus-support.master/opam
+++ b/packages/bap-primus-support/bap-primus-support.master/opam
@@ -36,7 +36,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
   "bare"

--- a/packages/bap-primus-test/bap-primus-test.master/opam
+++ b/packages/bap-primus-test/bap-primus-test.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-primus-x86/bap-primus-x86.master/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
   "bap-x86"

--- a/packages/bap-primus/bap-primus.master/opam
+++ b/packages/bap-primus/bap-primus.master/opam
@@ -26,7 +26,7 @@ depends: [
   "monads"
   "uuidm"
   "graphlib" {> "1.3.0"}
-  "parsexp"
+  "parsexp" {>= "v0.11" & < "v0.12"}
 ]
 synopsis: "The BAP Microexecution Framework"
 description: """

--- a/packages/bap-primus/bap-primus.master/opam
+++ b/packages/bap-primus/bap-primus.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-primus"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-abi"
   "bap-c"

--- a/packages/bap-print/bap-print.master/opam
+++ b/packages/bap-print/bap-print.master/opam
@@ -21,7 +21,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-demangle"
   "text-tags"

--- a/packages/bap-relocatable/bap-relocatable.master/opam
+++ b/packages/bap-relocatable/bap-relocatable.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "ogre"
 ]

--- a/packages/bap-report/bap-report.master/opam
+++ b/packages/bap-report/bap-report.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-report"]
          ["bapbundle" "remove" "report.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "A BAP plugin that reports program status"

--- a/packages/bap-run/bap-run.master/opam
+++ b/packages/bap-run/bap-run.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-server/bap-server.master/opam
+++ b/packages/bap-server/bap-server.master/opam
@@ -22,7 +22,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core-lwt"
   "regular"
   "bap"

--- a/packages/bap-server/bap-server.master/opam
+++ b/packages/bap-server/bap-server.master/opam
@@ -35,7 +35,7 @@ depends: [
   "lwt_log"
   "oasis" {build & >= "0.4.7"}
   "re"
-  "uri" {>= "1.9.6"}
+  "uri" {>= "2.0.0"}
 ]
 conflicts: [
     "tls" {< "0.7.1"}

--- a/packages/bap-ssa/bap-ssa.master/opam
+++ b/packages/bap-ssa/bap-ssa.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-ssa"]
          ["bapbundle" "remove" "ssa.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "A BAP plugin, that translates a program into the SSA form"

--- a/packages/bap-std/bap-std.master/opam
+++ b/packages/bap-std/bap-std.master/opam
@@ -30,7 +30,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "base-unix"
   "bap-future"
   "camlzip" {>= "1.07"}

--- a/packages/bap-strings/bap-strings.master/opam
+++ b/packages/bap-strings/bap-strings.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-strings"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build & >= "0.4.7"}
 ]

--- a/packages/bap-symbol-reader/bap-symbol-reader.master/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.master/opam
@@ -26,7 +26,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-taint-propagator/bap-taint-propagator.master/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
          ["bapbundle" "remove" "propagate_taint.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "cmdliner"
   "bap-microx"

--- a/packages/bap-taint/bap-taint.master/opam
+++ b/packages/bap-taint/bap-taint.master/opam
@@ -22,7 +22,7 @@ remove: [["ocamlfind" "remove" "bap-taint"]
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-term-mapper/bap-term-mapper.master/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.master/opam
@@ -25,7 +25,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-trace/bap-trace.master/opam
+++ b/packages/bap-trace/bap-trace.master/opam
@@ -25,7 +25,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "bap-traces"

--- a/packages/bap-traces/bap-traces.master/opam
+++ b/packages/bap-traces/bap-traces.master/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "uri" {>= "1.9.0"}

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.master/opam
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-trivial_condition_form"]
          ["bapbundle" "remove" "trivial_condition_form.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "Eliminates complex conditionals in branches"

--- a/packages/bap-veri/bap-veri.master/opam
+++ b/packages/bap-veri/bap-veri.master/opam
@@ -29,7 +29,8 @@ depends: [
   "oasis" {build}
   "ounit"
   "pcre"
-  "textutils"
+  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "textutils"   {>= "v0.11" & < "v0.12"}
   "uri"
 ]
 synopsis: "BAP Instruction Semantics Verification Tool"

--- a/packages/bap-veri/bap-veri.master/opam
+++ b/packages/bap-veri/bap-veri.master/opam
@@ -22,7 +22,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-traces"
   "cmdliner"

--- a/packages/bap-warn-unused/bap-warn-unused.master/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.master/opam
@@ -23,7 +23,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
         ["bapbundle" "remove" "warn_unused.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-x86/bap-x86.master/opam
+++ b/packages/bap-x86/bap-x86.master/opam
@@ -22,7 +22,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "master"}
   "bap-abi"
   "bap-c"

--- a/packages/bap/bap.master/opam
+++ b/packages/bap/bap.master/opam
@@ -9,7 +9,7 @@ dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-abi" {= "master"}
   "bap-api" {= "master"}
   "bap-arm" {= "master"}

--- a/packages/bare/bare.master/opam
+++ b/packages/bare/bare.master/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build}
-  "parsexp"
+  "parsexp" {>= "v0.11" & < "v0.12"}
 ]
 synopsis: "BAP Rule Engine Library"
 description: """

--- a/packages/bare/bare.master/opam
+++ b/packages/bare/bare.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bare"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build}
   "parsexp"

--- a/packages/core-lwt/core-lwt.master/opam
+++ b/packages/core-lwt/core-lwt.master/opam
@@ -22,7 +22,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "oasis" {build & >= "0.4.0"}
   "base-unix"
   "base-threads"

--- a/packages/graphlib/graphlib.master/opam
+++ b/packages/graphlib/graphlib.master/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build & >= "0.4.7"}
   "ppx_jane" {>= "v0.11" & < "v0.12"}

--- a/packages/monads/monads.master/opam
+++ b/packages/monads/monads.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "monads"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build & >= "0.4.7"}
 ]

--- a/packages/ogre/ogre.master/opam
+++ b/packages/ogre/ogre.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "ogre"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build & >= "0.4.7"}
   "monads"

--- a/packages/regular/regular.master/opam
+++ b/packages/regular/regular.master/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build & >= "0.4.7"}
   "ppx_jane" {>= "v0.11" & < "v0.12"}

--- a/packages/text-tags/text-tags.master/opam
+++ b/packages/text-tags/text-tags.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "text-tags"]]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.08.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "oasis" {build & >= "0.4.7"}
 ]


### PR DESCRIPTION
this PR reflects some changes from `bap-1.6-release` branch:
- adds upper constraints for `ocaml` 
- adds upper constraints for JaneStreet packages
- fixes `uri` constraint in bap-server