### PR TITLE
adds support for core_kernel.v0.12

### DIFF
--- a/packages/bap-abi/bap-abi.master/opam
+++ b/packages/bap-abi/bap-abi.master/opam
@@ -17,7 +17,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-abi"]
          ["bapbundle" "remove" "abi.plugin"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-api/bap-api.master/opam
+++ b/packages/bap-api/bap-api.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-api"]
          ["rm" "-rf" "%{prefix}%/share/bap-api/c"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-arm/bap-arm.master/opam
+++ b/packages/bap-arm/bap-arm.master/opam
@@ -22,7 +22,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-llvm"
   "bap-abi"

--- a/packages/bap-beagle/bap-beagle.master/opam
+++ b/packages/bap-beagle/bap-beagle.master/opam
@@ -19,7 +19,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-beagle"]
          ["bapbundle" "remove" "strings.plugin"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "cmdliner"
   "bap-microx"

--- a/packages/bap-bil/bap-bil.master/opam
+++ b/packages/bap-bil/bap-bil.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-bil"]
          ["bapbundle" "remove" "bil.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-build/bap-build.master/opam
+++ b/packages/bap-build/bap-build.master/opam
@@ -22,10 +22,10 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "ocamlbuild"
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane"
 ]
 

--- a/packages/bap-bundle/bap-bundle.master/opam
+++ b/packages/bap-bundle/bap-bundle.master/opam
@@ -16,11 +16,11 @@ remove: [["ocamlfind" "remove" "bap-bundle"]
          ["rm" "-f" "%{bin}%/bapbundle"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "uri"
   "camlzip"
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane"
   "fileutils"
 ]

--- a/packages/bap-byteweight-frontend/bap-byteweight-frontend.master/opam
+++ b/packages/bap-byteweight-frontend/bap-byteweight-frontend.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-byteweight"
   "cmdliner"

--- a/packages/bap-byteweight/bap-byteweight.master/opam
+++ b/packages/bap-byteweight/bap-byteweight.master/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-signatures"
 ]

--- a/packages/bap-c/bap-c.master/opam
+++ b/packages/bap-c/bap-c.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-c"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-api"
 ]

--- a/packages/bap-cache/bap-cache.master/opam
+++ b/packages/bap-cache/bap-cache.master/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-callsites/bap-callsites.master/opam
+++ b/packages/bap-callsites/bap-callsites.master/opam
@@ -25,7 +25,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-constant-tracker/bap-constant-tracker.master/opam
+++ b/packages/bap-constant-tracker/bap-constant-tracker.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-costant_tracker"]
          ["bapbundle" "remove" "constant_tracker.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-core-theory/bap-core-theory.master/opam
+++ b/packages/bap-core-theory/bap-core-theory.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-core-theory"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-knowledge" {= "master"}
   "bitvec" {= "master"}

--- a/packages/bap-cxxfilt/bap-cxxfilt.master/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.master/opam
@@ -21,7 +21,7 @@ remove: [
         ["bapbundle" "remove" "cxxfilt.plugin"]
 ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-demangle"
   "conf-binutils" {>= "0.2"}

--- a/packages/bap-demangle/bap-demangle.master/opam
+++ b/packages/bap-demangle/bap-demangle.master/opam
@@ -21,8 +21,8 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-disassemble/bap-disassemble.master/opam
+++ b/packages/bap-disassemble/bap-disassemble.master/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-disassemble"]
          ["bapbundle" "remove" "disassemble.plugin"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "Implements the disassembler command"

--- a/packages/bap-dump-symbols/bap-dump-symbols.master/opam
+++ b/packages/bap-dump-symbols/bap-dump-symbols.master/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-dwarf/bap-dwarf.master/opam
+++ b/packages/bap-dwarf/bap-dwarf.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-dwarf"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "BAP DWARF parsing library"

--- a/packages/bap-elementary/bap-elementary.master/opam
+++ b/packages/bap-elementary/bap-elementary.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-elementary"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-core-theory" {= "master"}
 ]

--- a/packages/bap-elf/bap-elf.master/opam
+++ b/packages/bap-elf/bap-elf.master/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-dwarf"
   "bitstring" {>= "3.0.0"}

--- a/packages/bap-frames/bap-frames.master/opam
+++ b/packages/bap-frames/bap-frames.master/opam
@@ -35,10 +35,10 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
-  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
+  "ppx_jane" {>= "v0.12" & < "v0.13"}
   "bap-std" {= "master"}
   "bap-traces" {= "master"}
   "piqi" {>= "0.7.4"}

--- a/packages/bap-frontc/bap-frontc.master/opam
+++ b/packages/bap-frontc/bap-frontc.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-frontc_parser"]
         ["bapbundle" "remove" "frontc_parser.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-c"
   "FrontC"

--- a/packages/bap-frontend/bap-frontend.master/opam
+++ b/packages/bap-frontend/bap-frontend.master/opam
@@ -24,11 +24,11 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"
-  "parsexp" {>= "v0.11" & < "v0.12"}
+  "parsexp" {>= "v0.12" & < "v0.13"}
 ]
 synopsis: "BAP frontend"
 description: "The command-line interface to the Binary Analysis Platform."

--- a/packages/bap-fsi-benchmark/bap-fsi-benchmark.master/opam
+++ b/packages/bap-fsi-benchmark/bap-fsi-benchmark.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["rm" "-f" "%{bin}%/bap-byteweight"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {<= "1.6"}
   "bap-ida"
   "bap-byteweight-frontend"

--- a/packages/bap-future/bap-future.master/opam
+++ b/packages/bap-future/bap-future.master/opam
@@ -17,8 +17,8 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-future"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build & >= "0.4.7"}
   "monads"
 ]

--- a/packages/bap-ida-plugin/bap-ida-plugin.master/opam
+++ b/packages/bap-ida-plugin/bap-ida-plugin.master/opam
@@ -18,7 +18,7 @@ remove: [
 
 ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap"
   "cmdliner"
 ]

--- a/packages/bap-ida-python/bap-ida-python.master/opam
+++ b/packages/bap-ida-python/bap-ida-python.master/opam
@@ -20,7 +20,7 @@ remove: [
     ["rm" "-rf" "%{prefix}%/share/%{name}%/"]
 ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap" {= "master"}
   "conf-ida"
 ]

--- a/packages/bap-ida/bap-ida.master/opam
+++ b/packages/bap-ida/bap-ida.master/opam
@@ -23,10 +23,10 @@ remove: [
         ["bapbundle" "remove" "ida.plugin"]
 ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "conf-ida"
   "bap-ida-python" {>= "1.5.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build & >= "0.4.7"}
   "fileutils"
   "re"

--- a/packages/bap-knowledge/bap-knowledge.master/opam
+++ b/packages/bap-knowledge/bap-knowledge.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "knowledge"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "monads"
 ]

--- a/packages/bap-lisp/bap-lisp.master/opam
+++ b/packages/bap-lisp/bap-lisp.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-lisp"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "parsexp"
   "bap-strings"
   "bap-knowledge"

--- a/packages/bap-llvm/bap-llvm.master/opam
+++ b/packages/bap-llvm/bap-llvm.master/opam
@@ -28,7 +28,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "cmdliner"
   "conf-env-travis"

--- a/packages/bap-main/bap-main.master/opam
+++ b/packages/bap-main/bap-main.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-main"] ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "base"
   "stdio"
   "cmdliner"

--- a/packages/bap-mc/bap-mc.master/opam
+++ b/packages/bap-mc/bap-mc.master/opam
@@ -26,9 +26,9 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "bap-std" {= "master"}
   "bap-main" {= "master"}
 ]

--- a/packages/bap-microx/bap-microx.master/opam
+++ b/packages/bap-microx/bap-microx.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-microx"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "A micro execution framework"

--- a/packages/bap-mips/bap-mips.master/opam
+++ b/packages/bap-mips/bap-mips.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-mips"]
          ["bapbundle" "remove" "mips.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-abi"
   "bap-c"

--- a/packages/bap-objdump/bap-objdump.master/opam
+++ b/packages/bap-objdump/bap-objdump.master/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-objdump"]
 	 ["bapbundle" "remove" "objdump.plugin"]
 ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "re"
   "cmdliner"

--- a/packages/bap-optimization/bap-optimization.master/opam
+++ b/packages/bap-optimization/bap-optimization.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-optimization"]
          ["bapbundle" "remove" "optimization.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "cmdliner"
 ]

--- a/packages/bap-phoenix/bap-phoenix.master/opam
+++ b/packages/bap-phoenix/bap-phoenix.master/opam
@@ -25,7 +25,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-piqi/bap-piqi.master/opam
+++ b/packages/bap-piqi/bap-piqi.master/opam
@@ -30,7 +30,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-plugins/bap-plugins.master/opam
+++ b/packages/bap-plugins/bap-plugins.master/opam
@@ -15,8 +15,8 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugins"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "cmdliner"
   "fileutils"
   "bap-bundle" {= "master"}

--- a/packages/bap-powerpc/bap-powerpc.master/opam
+++ b/packages/bap-powerpc/bap-powerpc.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-powerpc"]
          ["bapbundle" "remove" "powerpc.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-abi"
   "bap-c"
   "bap-primus" {= "master"}

--- a/packages/bap-primus-dictionary/bap-primus-dictionary.master/opam
+++ b/packages/bap-primus-dictionary/bap-primus-dictionary.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-primus-lisp/bap-primus-lisp.master/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.master/opam
@@ -21,7 +21,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-primus-machine/bap-primus-machine.master/opam
+++ b/packages/bap-primus-machine/bap-primus-machine.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-primus-machine"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "cmdliner"
 ]
 synopsis: "BAP bap-primus-machine library"

--- a/packages/bap-primus-powerpc/bap-primus-powerpc.master/opam
+++ b/packages/bap-primus-powerpc/bap-primus-powerpc.master/opam
@@ -16,8 +16,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-primus_powerpc"]
          ["bapbundle" "remove" "primus_powerpc.plugin"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-primus-region/bap-primus-region.master/opam
+++ b/packages/bap-primus-region/bap-primus-region.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-primus-support/bap-primus-support.master/opam
+++ b/packages/bap-primus-support/bap-primus-support.master/opam
@@ -36,7 +36,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
   "bare"

--- a/packages/bap-primus-test/bap-primus-test.master/opam
+++ b/packages/bap-primus-test/bap-primus-test.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-primus-x86/bap-primus-x86.master/opam
+++ b/packages/bap-primus-x86/bap-primus-x86.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
   "bap-x86"

--- a/packages/bap-primus/bap-primus.master/opam
+++ b/packages/bap-primus/bap-primus.master/opam
@@ -17,7 +17,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-primus"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-abi"
   "bap-c"
@@ -26,7 +26,7 @@ depends: [
   "monads"
   "uuidm"
   "graphlib" {= "master"}
-  "parsexp" {>= "v0.11" & < "v0.12"}
+  "parsexp" {>= "v0.12" & < "v0.13"}
 ]
 synopsis: "The BAP Microexecution Framework"
 description: """

--- a/packages/bap-print/bap-print.master/opam
+++ b/packages/bap-print/bap-print.master/opam
@@ -21,7 +21,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-demangle"
   "text-tags"

--- a/packages/bap-raw/bap-raw.master/opam
+++ b/packages/bap-raw/bap-raw.master/opam
@@ -16,8 +16,8 @@ remove: [["ocamlfind" "remove" "bap-plugin-raw"]
          ["bapbundle" "remove" "raw.plugin"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "ppx_jane"
   "bap-std" {= "master"}
   "bap-main" {= "master"}

--- a/packages/bap-recipe-command/bap-recipe-command.master/opam
+++ b/packages/bap-recipe-command/bap-recipe-command.master/opam
@@ -16,7 +16,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-recipe_command"]
           ["bapbundle" "remove" "recipe_command.plugin"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "base"
   "stdio"
   "parsexp"

--- a/packages/bap-recipe/bap-recipe.master/opam
+++ b/packages/bap-recipe/bap-recipe.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-recipe"]
          ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "base"
   "stdio"

--- a/packages/bap-relocatable/bap-relocatable.master/opam
+++ b/packages/bap-relocatable/bap-relocatable.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "ogre"
 ]

--- a/packages/bap-report/bap-report.master/opam
+++ b/packages/bap-report/bap-report.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-report"]
          ["bapbundle" "remove" "report.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "A BAP plugin that reports program status"

--- a/packages/bap-run/bap-run.master/opam
+++ b/packages/bap-run/bap-run.master/opam
@@ -20,7 +20,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-server/bap-server.master/opam
+++ b/packages/bap-server/bap-server.master/opam
@@ -22,14 +22,14 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "core-lwt"
   "regular"
   "bap"
   "cohttp" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "ezjsonm" {= "0.5.0"}
   "lwt" {>= "4.0.0" & < "5.0.0"}
   "lwt_log"

--- a/packages/bap-ssa/bap-ssa.master/opam
+++ b/packages/bap-ssa/bap-ssa.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-ssa"]
          ["bapbundle" "remove" "ssa.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "A BAP plugin, that translates a program into the SSA form"

--- a/packages/bap-std/bap-std.master/opam
+++ b/packages/bap-std/bap-std.master/opam
@@ -27,7 +27,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "base-unix"
   "bap-future" {= "master"}
   "bap-knowledge" {= "master"}
@@ -37,13 +37,13 @@ depends: [
   "bap-main" {= "master"}
   "bap-plugins" {= "master"}
   "camlzip" {>= "1.07"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
-  "bin_prot" {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
+  "bin_prot" {>= "v0.12" & < "v0.13"}
   "fileutils"
   "graphlib" {= "master"}
   "oasis" {build & >= "0.4.7"}
   "ocamlfind" {>= "1.5.6" & < "2.0"}
-  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "ppx_jane" {>= "v0.12" & < "v0.13"}
   "regular"
   "uri"
   "utop" {build & >= "2.0.0"}

--- a/packages/bap-strings/bap-strings.master/opam
+++ b/packages/bap-strings/bap-strings.master/opam
@@ -17,8 +17,8 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-strings"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build & >= "0.4.7"}
 ]
 synopsis: "Text utilities useful in Binary Analysis and Reverse Engineering"

--- a/packages/bap-symbol-reader/bap-symbol-reader.master/opam
+++ b/packages/bap-symbol-reader/bap-symbol-reader.master/opam
@@ -26,7 +26,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-taint-propagator/bap-taint-propagator.master/opam
+++ b/packages/bap-taint-propagator/bap-taint-propagator.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bap-plugin-propagate_taint"]
          ["bapbundle" "remove" "propagate_taint.plugin"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "cmdliner"
   "bap-microx"

--- a/packages/bap-taint/bap-taint.master/opam
+++ b/packages/bap-taint/bap-taint.master/opam
@@ -22,7 +22,7 @@ remove: [["ocamlfind" "remove" "bap-taint"]
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
 ]

--- a/packages/bap-term-mapper/bap-term-mapper.master/opam
+++ b/packages/bap-term-mapper/bap-term-mapper.master/opam
@@ -25,7 +25,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-map_terms"]
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-trace/bap-trace.master/opam
+++ b/packages/bap-trace/bap-trace.master/opam
@@ -25,7 +25,7 @@ remove: [
         ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "bap-traces"

--- a/packages/bap-traces/bap-traces.master/opam
+++ b/packages/bap-traces/bap-traces.master/opam
@@ -24,7 +24,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "uri" {>= "1.9.0"}

--- a/packages/bap-trivial-condition-form/bap-trivial-condition-form.master/opam
+++ b/packages/bap-trivial-condition-form/bap-trivial-condition-form.master/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "remove" "bap-plugin-trivial_condition_form"]
          ["bapbundle" "remove" "trivial_condition_form.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
 ]
 synopsis: "Eliminates complex conditionals in branches"

--- a/packages/bap-veri/bap-veri.master/opam
+++ b/packages/bap-veri/bap-veri.master/opam
@@ -20,15 +20,15 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-traces"
   "cmdliner"
   "oasis" {build}
   "ounit"
   "pcre"
-  "core_kernel" {>= "v0.11" & < "v0.12"}
-  "textutils"   {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
+  "textutils"   {>= "v0.12" & < "v0.13"}
   "uri"
 ]
 synopsis: "BAP Instruction Semantics Verification Tool"

--- a/packages/bap-warn-unused/bap-warn-unused.master/opam
+++ b/packages/bap-warn-unused/bap-warn-unused.master/opam
@@ -23,7 +23,7 @@ remove: [[ "ocamlfind" "remove" "bap-plugin-warn_unused"]
         ["bapbundle" "remove" "warn_unused.plugin"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bap-std" {= "master"}
   "cmdliner"

--- a/packages/bap-x86/bap-x86.master/opam
+++ b/packages/bap-x86/bap-x86.master/opam
@@ -22,7 +22,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-std" {= "master"}
   "bap-abi"
   "bap-c"

--- a/packages/bap/bap.master/opam
+++ b/packages/bap/bap.master/opam
@@ -9,7 +9,7 @@ dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
 license: "MIT"
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "bap-abi" {= "master"}
   "bap-api" {= "master"}
   "bap-arm" {= "master"}

--- a/packages/bare/bare.master/opam
+++ b/packages/bare/bare.master/opam
@@ -17,10 +17,10 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bare"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build}
-  "parsexp" {>= "v0.11" & < "v0.12"}
+  "parsexp" {>= "v0.12" & < "v0.13"}
 ]
 synopsis: "BAP Rule Engine Library"
 description: """

--- a/packages/bitvec-binprot/bitvec-binprot.master/opam
+++ b/packages/bitvec-binprot/bitvec-binprot.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [ ["ocamlfind" "remove" "bitvec-binprot"] ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bitvec"
   "bin_prot"

--- a/packages/bitvec-order/bitvec-order.master/opam
+++ b/packages/bitvec-order/bitvec-order.master/opam
@@ -14,7 +14,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bitvec-order"]]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "base"
   "bitvec"

--- a/packages/bitvec-sexp/bitvec-sexp.master/opam
+++ b/packages/bitvec-sexp/bitvec-sexp.master/opam
@@ -15,7 +15,7 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bitvec-sexp"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "bitvec"
   "sexplib0"

--- a/packages/bitvec/bitvec.master/opam
+++ b/packages/bitvec/bitvec.master/opam
@@ -14,8 +14,9 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bitvec"] ]
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
+  "ppx_jane" {>= "v0.12" & < "v0.13"}
   "zarith"
 ]
 synopsis: "Fixed-size bitvectors and modular arithmetic, based on Zarith"

--- a/packages/core-lwt/core-lwt.master/opam
+++ b/packages/core-lwt/core-lwt.master/opam
@@ -22,11 +22,11 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.0"}
   "base-unix"
   "base-threads"
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "lwt" {>= "4.0.0" & < "5.0.0"}
 ]
 synopsis: "Lwt library wrapper in the Janestreet core style"

--- a/packages/graphlib/graphlib.master/opam
+++ b/packages/graphlib/graphlib.master/opam
@@ -24,10 +24,10 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "ppx_jane" {>= "v0.12" & < "v0.13"}
   "ocamlgraph"
   "regular"
 ]

--- a/packages/monads/monads.master/opam
+++ b/packages/monads/monads.master/opam
@@ -17,8 +17,8 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "monads"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build & >= "0.4.7"}
 ]
 synopsis: "A missing monad library"

--- a/packages/ogre/ogre.master/opam
+++ b/packages/ogre/ogre.master/opam
@@ -17,8 +17,8 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "ogre"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build & >= "0.4.7"}
   "monads"
 ]

--- a/packages/regular/regular.master/opam
+++ b/packages/regular/regular.master/opam
@@ -24,10 +24,10 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build & >= "0.4.7"}
-  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "ppx_jane" {>= "v0.12" & < "v0.13"}
 ]
 synopsis: "Library for regular data types"
 description: """

--- a/packages/text-tags/text-tags.master/opam
+++ b/packages/text-tags/text-tags.master/opam
@@ -17,8 +17,8 @@ install: [[make "install"]]
 remove: [["ocamlfind" "remove" "text-tags"]]
 
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.08.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
+  "ocaml" {>= "4.07.1" & < "4.10.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13"}
   "oasis" {build & >= "0.4.7"}
 ]
 synopsis: "A library for rich formatting using semantics tags"


### PR DESCRIPTION
the next compilers are no longer supported: 4.04, 4.05, 4.06
and we add the next instead: 4.08 and 4.09