### PR TITLE
Add ppx_jane dependency to bap-recipe package.

### DIFF
--- a/packages/bap-recipe/bap-recipe.master/opam
+++ b/packages/bap-recipe/bap-recipe.master/opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml" {>= "4.07.1" & < "4.10.0"}
   "oasis" {build & >= "0.4.7"}
   "base"
+  "ppx_jane"
   "stdio"
   "parsexp"
   "fileutils"


### PR DESCRIPTION
A dependency error happens when installing all our opam packages at once, and opam decides to build `bap-recipe` before `ppx_jane` gets installed.