### PR TITLE
constrains ocaml-radare to 0.0.6 version

### DIFF
--- a/packages/bap-radare2/bap-radare2.master/opam
+++ b/packages/bap-radare2/bap-radare2.master/opam
@@ -25,7 +25,7 @@ depends: [
   "bap-knowledge"
   "bitvec"
   "core_kernel" {>= "v0.12" & < "v0.13"}
-  "radare2" {= "0.0.5"}
+  "radare2" {= "0.0.6"}
   "re"
   "yojson"
   "zarith"

--- a/packages/bap/bap.master/opam
+++ b/packages/bap/bap.master/opam
@@ -55,6 +55,7 @@ depends: [
   "bap-primus-propagate-taint" {= "master"}
   "bap-primus-x86" {= "master"}
   "bap-print" {= "master"}
+  "bap-radare2" {= "master"}
   "bap-raw" {= "master"}
   "bap-recipe" {= "master"}
   "bap-recipe-command" {= "master"}


### PR DESCRIPTION
re-enables `bap-radare2` package as a part of bap meta-package