### PR TITLE
updates depext dependencies for debian and fedora

### DIFF
--- a/packages/bap-llvm/bap-llvm.master/opam
+++ b/packages/bap-llvm/bap-llvm.master/opam
@@ -40,6 +40,7 @@ depexts: [
   ["clang" "libncurses5-dev"] {os-distribution = "ubuntu"}
   ["clang"] {os-distribution = "debian"}
   ["clang" "libxml2-dev"] {os-distribution = "alpine"}
+  ["clang"] {os-distribution = "fedora"}
 ]
 synopsis: "BAP LLVM backend"
 description:

--- a/packages/conf-bap-llvm/conf-bap-llvm.master/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.master/opam
@@ -16,7 +16,10 @@ depends: [
 depexts: [
 
   # debian
-  ["llvm-7-dev"] {os-distribution = "debian"}
+  ["llvm-6.0-dev"] {os-distribution = "debian" & os-version = "8"}       # jessie
+  ["llvm-7-dev"]   {os-distribution = "debian" & os-version = "9"}       # stretch
+  ["llvm-7-dev"]   {os-distribution = "debian" & os-version = "10"}      # buster
+  ["llvm-9-dev"]   {os-distribution = "debian" & os-version = "unknown"} # testing
 
   # ubuntu
   ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty
@@ -31,7 +34,7 @@ depexts: [
   ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}
   ["llvm@9"]   {os = "macos" & os-distribution = "homebrew"}
 
-  #alpine
+  # alpine
   ["llvm-dev" "llvm-static"] {os-distribution = "alpine"}
 ]
 


### PR DESCRIPTION
updates depext for:
- fedora
- debian jessie
- debian stretch
- debian buster
- debian testing

The latter one doesn't look nice, but it works, and there is
no other example in the opam-repository that we could use.