### PR TITLE
updates bap-radare2 dependecies

### DIFF
--- a/packages/bap-radare2/bap-radare2.master/opam
+++ b/packages/bap-radare2/bap-radare2.master/opam
@@ -25,7 +25,7 @@ depends: [
   "bap-knowledge"
   "bitvec"
   "core_kernel" {>= "v0.12" & < "v0.13"}
-  "radare2" {= "0.0.6"}
+  "conf-radare2"
   "re"
   "yojson"
   "zarith"


### PR DESCRIPTION
This PR replaces the `radare2` dependency with `conf-radare2`  for the package `bap-radare2` 