### PR TITLE
adds the bap-traces dependency to the bap-arm package

### DIFF
--- a/packages/bap-arm/bap-arm.master/opam
+++ b/packages/bap-arm/bap-arm.master/opam
@@ -38,6 +38,7 @@ depends: [
   "bap-api" {= "master"}
   "bap-c" {= "master"}
   "bap-primus" {= "master"}
+  "bap-traces" {= "master"}
 ]
 synopsis: "BAP ARM lifter and disassembler"
 description: """


### PR DESCRIPTION
Accompanying BinaryAnalysisPlatform/bap#1433