### PR TITLE
adds the bap-primus to the dependency list of x86

### DIFF
--- a/packages/bap-x86/bap-x86.master/opam
+++ b/packages/bap-x86/bap-x86.master/opam
@@ -35,6 +35,7 @@ depends: [
   "bap-core-theory" {= "master"}
   "bap-future" {= "master"}
   "bap-knowledge" {= "master"}
+  "bap-primus" {= "master"}
   "bap-llvm" {= "master"}
   "bap-main" {= "master"}
   "bap-std" {= "master"}


### PR DESCRIPTION
It is already implicitly dependent as part of the semantics of x86 is expressed in Primus Lisp, but soon there will be an explicit OCaml dependency, so it is better
to make the PR sooner than later.