### PR TITLE
removes the upper constraint for z3

### DIFF
--- a/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.master/opam
+++ b/packages/bap-primus-symbolic-executor/bap-primus-symbolic-executor.master/opam
@@ -30,7 +30,7 @@ depends: [
   "ppx_bap"
   "regular" {= "master"}
   "zarith"
-  "z3" {>= "4.8.8-1" & < "4.8.13"}
+  "z3" {>= "4.8.8-1"}
 ]
 synopsis: "Primus Symbolic Executor"
 description: """


### PR DESCRIPTION
We had this constraint because 4.8.13 was the last version that was using static linking. However, this version can't be installed on modern distributions as it requires python 2.7, which is no longer available.