### PR TITLE
constrains primus-lisp dependency on ppx_bap to master version

### DIFF
--- a/packages/bap-primus-lisp/bap-primus-lisp.master/opam
+++ b/packages/bap-primus-lisp/bap-primus-lisp.master/opam
@@ -24,7 +24,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.08.0" }
   "core_kernel" {>= "v0.14" & < "v0.16"}
-  "ppx_bap"
+  "ppx_bap" {= "master"}
   "bap-std" {= "master"}
   "bap-primus" {= "master"}
   "monads" {= "master"}


### PR DESCRIPTION
The older (v0.14)  version doesn't contain inline tests that are required by the primus-lisp package, so it won't build.